### PR TITLE
Feat/better measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ Currently, I'm working on turning this project into a more general library to tr
 - [x] add pytest tests
 - [x] add Interaction class to serve as a middleman between the environment and the agent, to remove need for custom handling loops
 - [x] add more environments and an easier way to use and install them
-- [ ] add better measurement (mean/min/max, episode lenghts, details of exploration, etc)
-- [ ] add Prioritized Experience Replay
+- [x] add better measurement (mean/min/max, episode lenghts, details of exploration, etc)
 - [ ] add hyperparameter tuning and improve the models
+- [ ] add Prioritized Experience Replay
 - [ ] add environments for Sarsa type agents
-- [ ] add capability to train the agent from pixel data
+- [ ] add an example of training and agent from pixel data
 - [ ] upgrade ML-Agents package to the latest Release 1
 - [ ] add PPO, Dueling DQN and other algorithms (to be decided)
 

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -65,6 +65,7 @@ class RandomAgent(Agent):
         return
 
     def new_episode(self):
+        # RandomAgent has no metrics to output
         return
 
     def act(self, state):

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -64,6 +64,13 @@ class RandomAgent(Agent):
         Args:
             state (np.ndarray): the input is disregarded, only shape is checked
 
+        Raises:
+            TypeError: if state shape does not match expectation
+
+        Returns:
+            np.ndarray: a random move, an integer (for discrete agent) or array
+                of floats for continuous agent
+
         """
         if np.shape(state) != self.expected_state_shape:
             raise TypeError("input shape does not match expectation")

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -24,6 +24,10 @@ class Agent(abc.ABC):
     def save(self, directory):
         pass
 
+    @abc.abstractmethod
+    def exploration(self, boolean):
+        pass
+
 
 class RandomAgent(Agent):
     """Agent which acts randomly and does not learn.
@@ -52,8 +56,13 @@ class RandomAgent(Agent):
         self.action_size = action_size
         self.action_type = action_type
         self.num_agents = num_agents
+        self.randomness = True
 
         self.expected_state_shape = (self.num_agents, self.space_size)
+
+    def exploration(self, boolean):
+        # RandomAgent acts always randomly, it cannot be changed
+        return
 
     def new_episode(self):
         return

--- a/agent/ddpg.py
+++ b/agent/ddpg.py
@@ -40,7 +40,7 @@ class Actor(nn.Module):
     def forward(self, state):
         x = F.relu(self.fc1(state))
         x = F.relu(self.fc2(x))
-        return F.tanh(self.fc3(x))
+        return torch.tanh(self.fc3(x))
 
 
 class Critic(nn.Module):

--- a/agent/ddpg.py
+++ b/agent/ddpg.py
@@ -146,7 +146,8 @@ class DDPGAgent(Agent):
     def exploration(self, boolean):
         """Controls whether randomness is added to chosen actions.
 
-        boolean (bool): True or False, default True
+        Args:
+            boolean (bool): True or False, default True
 
         """
         self.explore = bool(boolean)
@@ -167,8 +168,11 @@ class DDPGAgent(Agent):
                 self._learn(experiences, self.gamma)
 
     def act(self, state):
-        """Return action for given state as per current policy."""
+        """Return action for given state as per current policy.
+        
+        If exploration is turned on, adds some noise to the action.
 
+        """
         state = torch.from_numpy(state).float().to(device)
 
         self.actor_local.eval()

--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -1,5 +1,7 @@
 import os
 import random
+from collections import deque
+from statistics import mean
 
 import numpy as np
 import torch
@@ -90,8 +92,27 @@ class DQNAgent(Agent):
         self.eps_decay = eps_decay
         self.timestep = 0
 
+        self.eps_at_episode_start = eps_start
+        self._loss_history = deque()
+
     def new_episode(self):
-        return
+        """Returns statistics on the previous episode."""
+
+        if len(self._loss_history) > 0:
+            loss = mean(self._loss_history)
+            loss_max = max(self._loss_history)
+        else:
+            loss, loss_max = 0., 0.
+
+        history = {
+            'epsilon': self.eps_at_episode_start,
+            'loss': loss,
+            'loss_max': loss_max
+        }
+
+        self.eps_at_episode_start = self.epsilon
+        self._loss_history.clear()
+        return history
 
     def exploration(self, boolean):
         """Controls whether randomness is added to chosen actions.
@@ -188,7 +209,6 @@ class DQNAgent(Agent):
         dones = torch.as_tensor(dones, dtype=torch.int8).unsqueeze(-1)
 
         Q_targets_next = self.qnetwork_target(next_states).detach().max(1)[0].unsqueeze(1)
-
         Q_targets = rewards + (gamma * Q_targets_next * (1 - dones))
         Q_expected = self.qnetwork_local(states).gather(1, actions)
 
@@ -198,6 +218,8 @@ class DQNAgent(Agent):
         self.optimizer.step()
 
         self._soft_update(self.qnetwork_local, self.qnetwork_target, self.tau)
+
+        self._loss_history.append(loss.float().item())
 
     def _soft_update(self, local_model, target_model, tau):
         """Soft update model parameters.

--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -96,7 +96,8 @@ class DQNAgent(Agent):
     def exploration(self, boolean):
         """Controls whether randomness is added to chosen actions.
 
-        boolean (bool): True or False, default True
+        Args:
+            boolean (bool): True or False, default True
 
         """
         self.explore = bool(boolean)
@@ -107,6 +108,9 @@ class DQNAgent(Agent):
         Uses epsilon-greedy action selection. When epsilon is 1.0,
         the action is totally random. When epsilon is 0.0 the returned
         action is always the best action according the current policy.
+
+        If exploration is turned off, epsilon-greedy action selection
+        is disabled and actions are deterministic.
 
         Args:
             state (array_like): current state

--- a/agent/dqn.py
+++ b/agent/dqn.py
@@ -84,6 +84,7 @@ class DQNAgent(Agent):
 
         self.memory = ReplayBuffer(self.replay_buffer_size, batch_size, seed)
 
+        self.explore = True
         self.epsilon = eps_start
         self.eps_end = eps_end
         self.eps_decay = eps_decay
@@ -91,6 +92,14 @@ class DQNAgent(Agent):
 
     def new_episode(self):
         return
+
+    def exploration(self, boolean):
+        """Controls whether randomness is added to chosen actions.
+
+        boolean (bool): True or False, default True
+
+        """
+        self.explore = bool(boolean)
 
     def act(self, state, eps=None):
         """Returns action for given state as per current policy.
@@ -110,7 +119,7 @@ class DQNAgent(Agent):
 
         epsilon = eps if eps is not None else self.epsilon
 
-        if random.random() > epsilon:
+        if not self.explore or random.random() > epsilon:
 
             state = torch.from_numpy(state).float().unsqueeze(0).to(device)
             self.qnetwork_local.eval()
@@ -120,8 +129,7 @@ class DQNAgent(Agent):
 
             return np.argmax(action_values.cpu().data.numpy())
 
-        else:
-            return random.choice(np.arange(self.action_size))
+        return random.randrange(self.action_size)
 
     def step(self, state, action, reward, next_state, done):
         """Informs the agent of the consequences of an action so that

--- a/agent/helper.py
+++ b/agent/helper.py
@@ -1,22 +1,32 @@
 import os
+import json
 import matplotlib.pyplot as plt
 
-MODEL_DIR = 'models'
-SCORE_FILENAME = 'scores.png'
-
-def get_model_dir(modelname):
+def get_model_dir(model_name, model_dir='models'):
     """Convenience function to get the directory where to save the model."""
-    return os.path.join(os.getcwd(), MODEL_DIR, modelname)
+    return os.path.join(os.getcwd(), model_dir, model_name)
 
-def create_model_dir(modelname):
+def create_model_dir(model_name, model_dir='models'):
     """Convenience function to create a directory where to save the model."""
-    os.mkdir(os.path.join(os.getcwd(), MODEL_DIR, modelname))
+    os.mkdir(os.path.join(os.getcwd(), model_dir, model_name))
 
-def save_scores(modelname, scores):
-    """Convenience function to save scores as a graph."""
+def save_graph(modelname, graph_data, ylabel='scores', filename='scores.png'):
+    """Convenience function to save graphs (e.g. scores).
 
-    plt.plot(list(range(1, len(scores) + 1)), scores)
-    plt.ylabel('score')
+    Args:
+        graph_data (list): a list of numbers to plot
+
+    """
+    plt.plot(list(range(1, len(graph_data) + 1)), graph_data)
+    plt.ylabel(ylabel)
     plt.xlabel('episode')
-    save_path = os.path.join(get_model_dir(modelname), SCORE_FILENAME)
+    save_path = os.path.join(get_model_dir(modelname), filename)
     plt.savefig(save_path)
+
+def save_history(model_name, history, filename='history.json'):
+    """Save json output of class `History` in into a file."""
+
+    str_data = json.dumps(history, ensure_ascii=False, indent=4)
+    save_path = os.path.join(get_model_dir(model_name), filename)
+    with open(save_path, 'w+') as output_file:
+        output_file.write(str_data)

--- a/agent/history.py
+++ b/agent/history.py
@@ -1,0 +1,103 @@
+import copy
+from collections import deque
+
+import numpy as np
+
+class TrainingHistory:
+    """Class to record training history."""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """Resets internal training history."""
+
+        self._scores_window = None
+        self._training_history = {
+            'episode_length': [],
+            'reward_max': [],
+            'reward_min': [],
+            'reward_mean': [],
+            'reward_std': [],
+            'score': []}
+
+    @property
+    def num_episodes(self):
+        """Return the amount of episodes trained."""
+        return len(self._training_history['episode_length'])
+
+    @property
+    def prev_episode_length(self):
+        """Previous episode's length."""
+        return self._training_history['episode_length'][-1]
+
+    @property
+    def prev_reward_max(self):
+        """Previous episode's max total reward collected by an agent."""
+        return self._training_history['reward_max'][-1]
+
+    @property
+    def prev_reward_min(self):
+        """Previous episode's min total reward collected by an agent."""
+        return self._training_history['reward_min'][-1]
+
+    @property
+    def prev_reward_mean(self):
+        """Previous episode's mean total reward collected by the agent(s)."""
+        return self._training_history['reward_mean'][-1]
+
+    @property
+    def prev_reward_std(self):
+        """Previous episode's standard deviation for total rewards collected
+        by the agent(s)."""
+        return self._training_history['reward_std'][-1]
+
+    @property
+    def prev_score(self):
+        """Previous episode's score by the agent(s)."""
+        return self._training_history['score'][-1]
+
+    def as_dict(self):
+        """Returns the training history as a dictionary."""
+        return copy.deepcopy(self._training_history)
+
+    def start_training(self, score_window_size=100):
+        """Called when new training session starts so that training
+        score can be calculated correctly.
+
+        Args:
+            scores_window_size (int): window size for calculating score
+
+        """
+        self._scores_window = deque(maxlen=score_window_size)
+
+    def update(self, episode_length, episode_rewards):
+        """Updates internal training history.
+
+        Args:
+            episode_length (int): length of the episode
+            episode_rewards (list): total rewards collected during the episode
+                by each agent
+
+        """
+        reward_episode_max = np.max(episode_rewards)
+        reward_episode_min = np.min(episode_rewards)
+        reward_episode_mean = np.mean(episode_rewards)
+        reward_episode_std = np.std(episode_rewards)
+
+        self._training_history['episode_length'].append(episode_length)
+        self._training_history['reward_max'].append(reward_episode_max)
+        self._training_history['reward_min'].append(reward_episode_min)
+        self._training_history['reward_mean'].append(reward_episode_mean)
+        self._training_history['reward_std'].append(reward_episode_std)
+
+        score = self._calculate_score(episode_rewards)
+        self._training_history['score'].append(score)
+
+    def _calculate_score(self, episode_rewards):
+        """Calculates training score for `update()`."""
+
+        reward_episode_max = np.max(episode_rewards)
+        self._scores_window.append(reward_episode_max)
+        score_window_mean = np.mean(self._scores_window)
+        return score_window_mean

--- a/agent/interaction.py
+++ b/agent/interaction.py
@@ -59,6 +59,8 @@ class UnityInteraction:
             dict: episode lengths and rewards for each episode
 
         """
+        self._agent.exploration(False)
+
         history = History()
 
         for i_episode in range(1, num_episodes + 1):
@@ -115,6 +117,8 @@ class UnityInteraction:
             dict: episode lengths and rewards for each episode
 
         """
+
+        self._agent.exploration(True)
 
         if score_target is None:
             score_target = float('inf')

--- a/banana.py
+++ b/banana.py
@@ -6,7 +6,8 @@ from unityagents import UnityEnvironment
 import numpy as np
 
 from agent.interaction import UnityInteraction
-from agent.helper import get_model_dir, create_model_dir, save_scores
+from agent.helper import (
+    get_model_dir, create_model_dir, save_graph, save_history)
 from agent import DQNAgent
 from agent.agent import RandomAgent
 
@@ -37,18 +38,19 @@ def train(modelname):
     state_size, action_size, num_agents = UnityInteraction.stats(env)
     agent = DQNAgent(state_size, action_size, num_agents, **MODEL_PARAMS)
 
-    # create train or run loop
+    # and create an interaction between them
     sim = UnityInteraction(agent, env)
 
     if modelname is not None:
         create_model_dir(modelname)
 
-    scores = sim.train(**TRAINING_PARAMS)
+    history = sim.train(**TRAINING_PARAMS)
 
     if modelname is not None:
         modeldir = os.path.join(get_model_dir(modelname))
         agent.save(modeldir)
-        save_scores(modelname, scores)
+        save_history(modelname, history)
+        save_graph(modelname, history['score'])
 
     env.close()
 
@@ -63,9 +65,10 @@ def run(modelname):
     modelfile = os.path.join(get_model_dir(modelname))
     agent.load(modelfile)
 
-    # create train or run loop
+    # run simulation
     sim = UnityInteraction(agent, env)
     sim.run()
+
     env.close()
 
 def random_run():

--- a/banana.py
+++ b/banana.py
@@ -25,7 +25,7 @@ MODEL_PARAMS = {
 TRAINING_PARAMS = {
     'num_episodes': 500,
     'max_time_steps': 300,
-    'target_score': 13.0,
+    'score_target': 13.0,
 }
 
 def train(modelname):

--- a/crawler.py
+++ b/crawler.py
@@ -26,7 +26,7 @@ MODEL_PARAMS = {
 TRAINING_PARAMS = {
     'num_episodes': 300,
     'max_time_steps': 1000,
-    'target_score': 2000.0,
+    'score_target': 2000.0,
 }
 
 

--- a/crawler.py
+++ b/crawler.py
@@ -5,7 +5,8 @@ import argparse
 from unityagents import UnityEnvironment
 
 from agent.interaction import UnityInteraction
-from agent.helper import get_model_dir, create_model_dir, save_scores
+from agent.helper import (
+    get_model_dir, create_model_dir, save_graph, save_history)
 from agent.ddpg import DDPGAgent
 from agent.agent import RandomAgent
 
@@ -39,18 +40,19 @@ def train(modelname):
     state_size, action_size, num_agents = UnityInteraction.stats(env)
     agent = DDPGAgent(state_size, action_size, num_agents, **MODEL_PARAMS)
 
-    # create train or run loop
+    # and create an interaction between them
     sim = UnityInteraction(agent, env)
 
     if modelname is not None:
         create_model_dir(modelname)
 
-    scores = sim.train(**TRAINING_PARAMS)
+    history = sim.train(**TRAINING_PARAMS)
 
     if modelname is not None:
         modelfile = os.path.join(get_model_dir(modelname))
         agent.save(modelfile)
-        save_scores(modelname, scores)
+        save_history(modelname, history)
+        save_graph(modelname, history['score'])
 
     env.close()
 

--- a/reacher.py
+++ b/reacher.py
@@ -5,7 +5,8 @@ import argparse
 from unityagents import UnityEnvironment
 
 from agent.interaction import UnityInteraction
-from agent.helper import get_model_dir, create_model_dir, save_scores
+from agent.helper import (
+    get_model_dir, create_model_dir, save_graph, save_history)
 from agent.ddpg import DDPGAgent
 from agent.agent import RandomAgent
 
@@ -39,18 +40,19 @@ def train(modelname):
     state_size, action_size, num_agents = UnityInteraction.stats(env)
     agent = DDPGAgent(state_size, action_size, num_agents, **MODEL_PARAMS)
 
-    # create train or run loop
+    # and create an interaction between them
     sim = UnityInteraction(agent, env)
 
     if modelname is not None:
         create_model_dir(modelname)
 
-    scores = sim.train(**TRAINING_PARAMS)
+    history = sim.train(**TRAINING_PARAMS)
 
     if modelname is not None:
         modeldir = os.path.join(get_model_dir(modelname))
         agent.save(modeldir)
-        save_scores(modelname, scores)
+        save_history(modelname, history)
+        save_graph(modelname, history['score'])
 
     env.close()
 

--- a/reacher.py
+++ b/reacher.py
@@ -26,7 +26,7 @@ MODEL_PARAMS = {
 TRAINING_PARAMS = {
     'num_episodes': 300,
     'max_time_steps': 1000,
-    'target_score': 30.,
+    'score_target': 30.,
 }
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+
+import pytest
+
+from agent.history import TrainingHistory
+
+class TestHistory:
+    """Tests the class `History` which provides training history for the
+    `Interaction` class."""
+
+    def test_properties(self):
+
+        hist = TrainingHistory()
+        hist.start_training()
+
+        episode_length = [1, 2]
+        episode_rewards = [[4.0, 5.0], [2.0, 4.0]]
+        for length, rewards in zip(episode_length, episode_rewards):
+            hist.update(length, rewards)
+
+        assert hist.num_episodes == 2
+        assert hist.prev_episode_length == 2
+        assert hist.prev_reward_max == 4.0
+        assert hist.prev_reward_min == 2.0
+        assert hist.prev_reward_mean == 3.0
+        assert hist.prev_reward_std == 1.0
+
+    def test_score_calculation(self):
+        assert False

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,7 +2,8 @@ from collections import namedtuple
 
 import pytest
 
-from agent.history import TrainingHistory
+from agent.history import History
+
 
 class TestHistory:
     """Tests the class `History` which provides training history for the
@@ -10,8 +11,7 @@ class TestHistory:
 
     def test_properties(self):
 
-        hist = TrainingHistory()
-        hist.start_training()
+        hist = History()
 
         episode_length = [1, 2]
         episode_rewards = [[4.0, 5.0], [2.0, 4.0]]
@@ -24,6 +24,3 @@ class TestHistory:
         assert hist.prev_reward_min == 2.0
         assert hist.prev_reward_mean == 3.0
         assert hist.prev_reward_std == 1.0
-
-    def test_score_calculation(self):
-        assert False

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -10,7 +10,6 @@ class TestHistory:
     `Interaction` class."""
 
     def test_properties(self):
-
         hist = History()
 
         episode_length = [1, 2]
@@ -19,8 +18,18 @@ class TestHistory:
             hist.update(length, rewards)
 
         assert hist.num_episodes == 2
-        assert hist.prev_episode_length == 2
-        assert hist.prev_reward_max == 4.0
-        assert hist.prev_reward_min == 2.0
-        assert hist.prev_reward_mean == 3.0
-        assert hist.prev_reward_std == 1.0
+        assert hist.episode_length == 2
+        assert hist.reward_max == 4.0
+        assert hist.reward_min == 2.0
+        assert hist.reward_mean == 3.0
+        assert hist.reward_std == 1.0
+
+    def test_add_and_get_key(self):
+        hist = History()
+
+        expected_output = 2.0
+        hist.add_from({'test_key': 1.0})
+        hist.add_from({'test_key': expected_output})
+        output = hist.get_latest('test_key')
+
+        assert output == expected_output

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -60,10 +60,14 @@ class TestInteraction:
         sim = UnityInteraction(agent, env)
 
         num_episodes = 2
-        scores = sim.run(num_episodes=num_episodes, max_time_steps=2)
+        max_time_steps = 2
+        history = sim.run(
+            num_episodes=num_episodes,
+            max_time_steps=max_time_steps)
         env.close()
 
-        assert len(scores) == num_episodes
+        assert len(history['episode_length']) == num_episodes
+        assert history['episode_length'][0] == max_time_steps
 
     def test_training_reacher_returns_scores(self):
 
@@ -84,7 +88,6 @@ class TestInteraction:
         history = sim.train(
             num_episodes=num_episodes,
             max_time_steps=max_time_steps)
-
         env.close()
 
         assert len(history['episode_length']) == num_episodes
@@ -105,10 +108,14 @@ class TestInteraction:
         sim = UnityInteraction(agent, env)
 
         num_episodes = 2
-        scores = sim.run(num_episodes=num_episodes, max_time_steps=2)
+        max_time_steps = 2
+        history = sim.run(
+            num_episodes=num_episodes,
+            max_time_steps=max_time_steps)
         env.close()
 
-        assert len(scores) == num_episodes
+        assert len(history['episode_length']) == num_episodes
+        assert history['episode_length'][0] == max_time_steps
 
     def test_training_banana_returns_scores(self):
 
@@ -129,7 +136,6 @@ class TestInteraction:
         history = sim.train(
             num_episodes=num_episodes,
             max_time_steps=max_time_steps)
-
         env.close()
 
         assert len(history['episode_length']) == num_episodes

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -10,7 +10,8 @@ from agent.agent import RandomAgent
 class TestInteraction:
     """Tests Interaction class with a randomly behaving agent and a mock Unity environment.
 
-    These tests are end-to-end type of tests, testing several components at once.
+    These tests are integration type of tests (testing several components at once). Aim is
+    to not check for specific outputs, but to check nothing crashes.
 
     """
     twenty_reachers_config = {
@@ -79,10 +80,15 @@ class TestInteraction:
         sim = UnityInteraction(agent, env)
 
         num_episodes = 2
-        scores = sim.train(num_episodes=num_episodes, max_time_steps=2)
+        max_time_steps = 2
+        history = sim.train(
+            num_episodes=num_episodes,
+            max_time_steps=max_time_steps)
+
         env.close()
 
-        assert len(scores) == num_episodes
+        assert len(history['episode_length']) == num_episodes
+        assert history['episode_length'][0] == max_time_steps
 
     def test_running_banana_returns_scores(self):
 
@@ -119,7 +125,12 @@ class TestInteraction:
         sim = UnityInteraction(agent, env)
 
         num_episodes = 2
-        scores = sim.train(num_episodes=num_episodes, max_time_steps=2)
+        max_time_steps = 2
+        history = sim.train(
+            num_episodes=num_episodes,
+            max_time_steps=max_time_steps)
+
         env.close()
 
-        assert len(scores) == num_episodes
+        assert len(history['episode_length']) == num_episodes
+        assert history['episode_length'][0] == max_time_steps


### PR DESCRIPTION
Added better measurement to better see what is happening during training and to facilitate hyperparameter tuning:
- make training loop return episode lengths and mean/std/min/max for rewards
- make agents return details of exploration and losses into history
- add helpers for saving history and graph
- add exploration on/off switch into agents
- fix userwarning for nn.functional.tanh deprecation
